### PR TITLE
disambiguate threshold

### DIFF
--- a/src/disambiguate-pre/annotate_corpora.jl
+++ b/src/disambiguate-pre/annotate_corpora.jl
@@ -22,7 +22,7 @@ function annotate_word(outfile, separator, threshold, vm, dict, word, context)
     if id != -1
         priors = expected_pi(vm, id)
         if length(find(priors .> threshold)) > 1
-            probs = disambiguate(vm, dict, word, context)
+            probs = disambiguate(vm, dict, word, context, true, threshold)
             best_sense = findmax(probs)[2]
             output_word = word * separator * string(best_sense)
         end


### PR DESCRIPTION
implemented threshold for disambiguate() function in annotate_corpora.jl
This allows that only senses with more posterior than threshold are considering for annotating the corpus, thus reducing the relevance of uncommon senses