### PR TITLE
Parse eval positions

### DIFF
--- a/src/parse_evaluator/parse_evaluator.py
+++ b/src/parse_evaluator/parse_evaluator.py
@@ -23,15 +23,15 @@ def Load_File(filename):
     print("Finished loading")
 
     # remove initial newlines, if any
-    while data[0] == "\n":
-        data.pop(0)
+    # while data[0] == "\n":
+    #     data.pop(0)
 
     return data
 
 def Get_Parses(data):
     """
-        Reads parses from data into two structures:
-        - sentences: a dictionary of indexed split sentence strings
+        Reads parses from data, counting number of parses by newlines
+        - num_parses: number of parses in data
         - parses: a list of lists containing the split links of each parse
         [
           [[link1-parse1][link2-parse1] ... ]
@@ -41,28 +41,23 @@ def Get_Parses(data):
         Each list is splitted into tokens using space.
     """
     parses = []
-    sentences = {}
-    parse_num = 0
+    parse_num = -1
+    sent_lengths = []
     new_flag = True
     for line in data:
         if line == "\n":
             # get rid of sentences with no links
-            if (not new_flag):
-                if (len(sentences[parse_num]) == 0):
-                    sentences.pop(parse_num)
-                    parse_num -= 1
-                    #dictionary.pop(parse_num) # not needed, it will be re-written
-                parse_num += 1
-                new_flag = True
+            new_flag = True
             continue
         if new_flag:
-            sentences[parse_num] = line.split() # split ignores diff spacing between words
             new_flag = False
+            sent_lengths.append(len(line.split()))
             parses.append([])
+            parse_num += 1
             continue
         parses[parse_num].append(line.split())
 
-    return parses, sentences
+    return parses, sent_lengths
 
 def MakeSets(parse):
     """
@@ -72,40 +67,31 @@ def MakeSets(parse):
     link_sets = [{(link[0], link[1]), (link[2], link[3])} for link in parse]
     return link_sets
 
-def Evaluate_Parses(test_parses, test_sentences, ref_parses, ref_sentences, verbose, ignore):
+def Evaluate_Parses(test_parses, ref_parses, ref_lengths, verbose, ignore):
     """
         Compares test_parses against ref_parses link by link
         counting errors
     """
-    evaluated_parses = 0  # reference parses not found in test
+    evaluated_parses = 0 
     total_links = 0     # in gold standard
     #extra_links = 0     # links present in test, but not in ref
     missing_links = 0   # links present in ref, but not in test
     ignored_links = 0   # ignored links, if ignore is active
     score = 0           # parse quality counter
 
-    for ref_key, ref_sent in ref_sentences.items():
-        # search if the current ref_sentence was wholly parsed in test_sentences
-        test_key = [key for key, sentence in test_sentences.items() if sentence == ref_sent]
-        if len(test_key) == 0:
-            if verbose:
-                print("Skipping sentence not found in test parses:")
-                print(ref_sent)
-            continue
-        test_sentences.pop(test_key[0]) # reduce the size of dict to search
+    for ref_parse, test_parse, sent_length in zip(ref_parses, test_parses, ref_lengths):
 
         current_missing = 0
         current_evaluated = 0
         current_ignored = 0
-        ref_sets = MakeSets(ref_parses[ref_key])  # using sets to ignore link directions
-        test_sets = MakeSets(test_parses[test_key[0]])
-        sent_length = str(len(ref_sent))
+        ref_sets = MakeSets(ref_parse)  # using sets to ignore link directions
+        test_sets = MakeSets(test_parse)
 
         # loop over every ref link and try to find it in test
         for ref_link in ref_sets:
             total_links += 1
             if ignore:
-                if (('0', '###LEFT-WALL###') in ref_link) or ((sent_length, ".") in ref_link):
+                if (('0', '###LEFT-WALL###') in ref_link) or ((str(sent_length), ".") in ref_link):
                     current_ignored += 1
                     continue
             current_evaluated += 1
@@ -123,7 +109,7 @@ def Evaluate_Parses(test_parses, test_sentences, ref_parses, ref_sentences, verb
         evaluated_parses += 1
 
         if verbose:
-            print("Sentence: {}".format(" ".join(ref_sent)))
+            #print("Sentence: {}".format(" ".join(ref_sent)))
             print("Missing links: {}".format(current_missing))
             print("Extra links: {}".format(len(test_sets)))
 
@@ -134,7 +120,7 @@ def Evaluate_Parses(test_parses, test_sentences, ref_parses, ref_sentences, verb
 
     score /= evaluated_parses # averages the score
     print("\nParse quality: {:.2%}".format(score))
-    print("A total of {} parses evaluated, {:.2%} of reference file".format(evaluated_parses, float(evaluated_parses) / len(ref_sentences)))
+    print("A total of {} parses evaluated, {:.2%} of reference file".format(evaluated_parses, float(evaluated_parses) / len(ref_parses)))
     print("A total of {} links".format(total_links))
     print("{:.2f} ignored links per sentence".format(ignored_links / evaluated_parses))
     print("{:.2f} missing links per sentence".format(missing_links / evaluated_parses))
@@ -192,12 +178,12 @@ def main(argv):
             ignore_WALL = False
 
     test_data = Load_File(test_file)
-    test_parses, test_sentences = Get_Parses(test_data) 
+    test_parses, test_lenghts = Get_Parses(test_data) 
     ref_data = Load_File(ref_file)
-    ref_parses, ref_sentences = Get_Parses(ref_data) 
-    if len(test_sentences) != len(ref_sentences):
+    ref_parses, ref_lengths = Get_Parses(ref_data) 
+    if len(test_parses) != len(ref_parses):
         sys.exit("ERROR: Number of parses differs in files")
-    Evaluate_Parses(test_parses, test_sentences, ref_parses, ref_sentences, verbose, ignore_WALL)
+    Evaluate_Parses(test_parses, ref_parses, ref_lengths, verbose, ignore_WALL)
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/src/parse_evaluator/parse_evaluator.py
+++ b/src/parse_evaluator/parse_evaluator.py
@@ -110,8 +110,10 @@ def Evaluate_Parses(test_parses, test_sentences, ref_parses, ref_sentences, verb
                     continue
             current_evaluated += 1
             if ref_link in test_sets:
+                print("found: {}".format(ref_link))
                 test_sets.remove(ref_link) 
             else:
+                print("missing: {}".format(ref_link))
                 current_missing += 1 # count links not contained in test
 
         # skip parse if there are no links left after ignore
@@ -193,6 +195,8 @@ def main(argv):
     test_parses, test_sentences = Get_Parses(test_data) 
     ref_data = Load_File(ref_file)
     ref_parses, ref_sentences = Get_Parses(ref_data) 
+    if len(test_sentences) != len(ref_sentences):
+        sys.exit("ERROR: Number of parses differs in files")
     Evaluate_Parses(test_parses, test_sentences, ref_parses, ref_sentences, verbose, ignore_WALL)
 
 if __name__ == '__main__':

--- a/src/parse_evaluator/parse_evaluator.py
+++ b/src/parse_evaluator/parse_evaluator.py
@@ -61,7 +61,7 @@ def Get_Parses(data):
 
 def MakeSets(parse):
     """
-        Gets a list with links (without full sentence) and
+        Gets a list with links (without full sentence)
         and makes sets for each link's ids
     """
     link_sets = [{(link[0], link[1]), (link[2], link[3])} for link in parse]
@@ -79,6 +79,17 @@ def Evaluate_Parses(test_parses, ref_parses, ref_lengths, verbose, ignore):
     ignored_links = 0   # ignored links, if ignore is active
     score = 0           # parse quality counter
 
+    def Remove_words(link_sets):
+        """
+            replace words in link with empty string
+            to compare links with sense-disambiguated words
+        """
+        wordless_sets = []
+        for link in link_sets:
+            wordless_sets.append({(link[0][0], ""), (link[1][0], "")})
+        return wordless_sets
+
+
     for ref_parse, test_parse, sent_length in zip(ref_parses, test_parses, ref_lengths):
 
         current_missing = 0
@@ -87,6 +98,8 @@ def Evaluate_Parses(test_parses, ref_parses, ref_lengths, verbose, ignore):
         ref_sets = MakeSets(ref_parse)  # using sets to ignore link directions
         test_sets = MakeSets(test_parse)
 
+        ref_wordless = Remove_words(ref_sets)
+        test_wordless = Remove_words(test_sets)
         # loop over every ref link and try to find it in test
         for ref_link in ref_sets:
             total_links += 1
@@ -95,7 +108,7 @@ def Evaluate_Parses(test_parses, ref_parses, ref_lengths, verbose, ignore):
                     current_ignored += 1
                     continue
             current_evaluated += 1
-            if ref_link in test_sets:
+            if ref_wordless in test_wordless:
                 print("found: {}".format(ref_link))
                 test_sets.remove(ref_link) 
             else:


### PR DESCRIPTION
Fixed parse evaluator to asses disambiguated words, also made more efficient.
Changes:
- Parses have to come in the same order as in reference file (also need to be the same number).
- Sets with links contain only word positions, not words. This allows disambiguated senses to be compared to ambiguous gold and silver standard. 
- Also, parser can work with LG parses that has ignored [words].