### PR TITLE
Square bracket filterring in .ull input

### DIFF
--- a/src/grammar_tester/lginprocparser.py
+++ b/src/grammar_tester/lginprocparser.py
@@ -52,7 +52,6 @@ class LGInprocParser(AbstractFileParserClient):
         end = trim_garbage(text)
 
         sent_count = 0
-        # sent_set = set()
 
         # Parse output to get sentences and linkages in postscript notation
         for sent in text[pos:end].split("\n\n"):
@@ -70,18 +69,7 @@ class LGInprocParser(AbstractFileParserClient):
 
             sentences.append(cur_sent)
 
-            # sent_set.add(cur_sent.text)
-
-            # set_len = len(sent_set)
-
-            # if (set_len == len(sent_set)):
-            #     print(cur_sent.text)
-
             sent_count += 1
-
-        # assert len(sent_set) == sent_count, "Duplicate sentences!"
-        # if len(sent_set) != sent_count:
-        #     print("Duplicate sentences found! len(sent_set): {},\t\tsent_count: {}".format(len(sent_set), sent_count))
 
         return sentences
 
@@ -209,12 +197,19 @@ class LGInprocParser(AbstractFileParserClient):
             print("Info: Reference file name is not specified. Parse quality is not calculated.")
 
 
+        # Getting only sentences from .ull and filtering out square brackets
         # sed -e '/\(^[0-9].*$\)\|\(^$\)/d;s/\[\([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27-]*\)\]/\1/g'
+
+        # The same with lowercase conversion
+        # sed '/\(^[0-9].*$\)\|\(^$\)/d;s/\[\([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27-]*\)\]/\1/g;s/.*/\L\0/g'
+
+        # Fixed for long dashes
+        # sed -e '/\(^[0-9].*$\)\|\(^$\)/d;s/\[\([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27\xE2\x80\x94-]*\)\]/\1/g'
 
         # If BIT_ULL_IN sed filters links leaving only sentences and removes square brackets around tokens if any.
         if (options & BIT_ULL_IN):
             sed_cmd = ["sed", "-e",
-                       r'/\(^[0-9].*$\)\|\(^$\)/d;s/\[\([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27-]*\)\]/\1/g',
+                       r'/\(^[0-9].*$\)\|\(^$\)/d;s/\[\([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27\xE2\x80\x94-]*\)\]/\1/g',
                        corpus_path]
 
         # Otherwise sed removes only empty lines.

--- a/src/grammar_tester/psparse.py
+++ b/src/grammar_tester/psparse.py
@@ -36,6 +36,42 @@ def strip_token(token) -> str:
     return token[:pos:]
 
 
+def find_end_of_token(text, start_pos: int) -> int:
+
+    # Assume the open brace is already skipped
+    braces = 1
+    brackets = 0
+
+    pos = start_pos
+    text_len = len(text)
+
+    while pos < text_len:
+
+        current = text[pos]
+
+        if current == r")":
+            # if not "[)]"
+            if not brackets:
+                # If not "())"
+                if pos + 1 >= text_len or text[pos + 1] != r")":
+                    braces -= 1
+
+            if not braces:
+                return pos
+
+        elif current == r"[":
+            # If not "([)"
+            if pos + 1 >= text_len or text[pos + 1] != r")":
+                brackets += 1
+
+        elif current == r"]" and brackets:
+            brackets -= 1
+
+        pos += 1
+
+    return pos
+
+
 def parse_tokens(txt, opt) -> (list, int):
     """
     Parse string of tokens, taken from postscript notated LG parse output.
@@ -49,9 +85,17 @@ def parse_tokens(txt, opt) -> (list, int):
     """
     tokens = []
     offset = 0
-    start_pos = 1
-    end_pos = txt.find(")")
 
+    # Skip the open brace
+    start_pos = 1
+
+    # end_pos = txt.find(")")
+    # end_pos = find_end_of_token(txt, start_pos)
+
+    end_pos = txt.find(")(")
+
+    if end_pos < 0:
+        end_pos = len(txt)-1
 
     while end_pos - start_pos > 0:
         token = txt[start_pos:end_pos:]
@@ -83,7 +127,13 @@ def parse_tokens(txt, opt) -> (list, int):
             tokens.append(token)
 
         start_pos = end_pos + 2
-        end_pos = txt.find(")", start_pos + 1)
+        # end_pos = txt.find(")", start_pos + 1)
+        # end_pos = find_end_of_token(txt, start_pos)
+
+        end_pos = txt.find(")(", start_pos + 1)
+
+        if end_pos < 0:
+            end_pos = len(txt)-1
 
     return tokens, offset
 
@@ -136,14 +186,14 @@ def prepare_tokens(tokens: list, options: int) -> list:
 
 def parse_links(txt: str, tokens: list, offset: int) -> list:
     """
-    Parse links represented in postfix notation and prints them in OpenCog notation.
+    Parse links represented in postfix notation and return them as a list of tuples.
 
     :param txt:         Link list in postfix notation, obtained either from LG API or from link-parser postfix output.
     :param tokens:      List of tokens previously extracted from postfix notated output.
     :param offset:      Token index offset. Equals to 1 if tested grammar has no LEFT-WALL and the former was added
                         during postscript parsing. Offset is necessary for the links to have their indexes properly
                         updated.
-    :return:            List of links in ULL format.
+    :return:            List of tuples representing token to token links.
     """
     links = []
 


### PR DESCRIPTION
Square bracket filterring while using .ull files as input corpora is implemented. Fixed bug in postscript parsing code.