### PR TITLE
Fixes for CircleCI test environment and unit tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM continuumio/miniconda3
 
-RUN useradd -ms /bin/bash  opencog-ull
+RUN apt-get update -qq && apt-get install -y locales -qq && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen 
+# RUN /usr/sbin/update-locale LANG=en_US.UTF-8
 
-ENV PYTHONUNBUFFERED 1
+ENV LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
-ADD https://github.com/singnet/language-learning/raw/master/environment.yml /tmp/environment.yml
+ADD https://github.com/alexei-gl/language-learning/raw/master/environment.yml /tmp/environment.yml
 
 WORKDIR /tmp
 
-RUN conda update -y -q conda && conda env create -f environment.yml -q
-RUN chown -R opencog-ull:opencog-ull /opt/conda
+RUN conda update -y -q conda && conda env create -f environment.yml -q && useradd -ms /bin/bash opencog-ull && chown -R opencog-ull:opencog-ull /opt/conda
 
 USER opencog-ull
 

--- a/conda/lg-5.5.1-minisat-bundled/build.sh
+++ b/conda/lg-5.5.1-minisat-bundled/build.sh
@@ -1,0 +1,6 @@
+./configure --prefix=$PREFIX --enable-sat-solver=bundled --enable-python-bindings=3
+make
+make check
+make install
+ldconfig -r $PREFIX -N
+make installcheck

--- a/conda/lg-5.5.1-minisat-bundled/meta.yaml
+++ b/conda/lg-5.5.1-minisat-bundled/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: link-grammar-minisat-bundled
+  version: "5.5.0"
+
+source:
+  url: https://www.abisource.com/downloads/link-grammar/5.5.0/link-grammar-5.5.0.tar.gz
+
+build:
+  number: 0
+
+requirements:
+  build:
+#    - make
+#    - m4
+#    - gcc
+#    - autoconf
+##    - autoconf-archive
+#    - pkg-config
+#    - flex
+#    - ant
+#    - graphviz
+  run:
+    -  libgcc
+#    -  geos
+#    -  proj4
+#    -  json-c
+#    -  libxml2
+#    -  postgresql >=9.1
+
+about:
+  home: https://www.abisource.com/projects/link-grammar/
+  license: GPL2

--- a/conda/lg-5.5.1-minisat-bundled/upload-link-grammar.sh
+++ b/conda/lg-5.5.1-minisat-bundled/upload-link-grammar.sh
@@ -1,0 +1,1 @@
+anaconda upload /home/alex/miniconda3/conda-bld/linux-64/link-grammar-minisat-bundled-5.5.0-0.tar.bz2

--- a/conda/sparsesvd-0.2.2/build.sh
+++ b/conda/sparsesvd-0.2.2/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt  # Python command to install the script.

--- a/conda/sparsesvd-0.2.2/meta.yaml
+++ b/conda/sparsesvd-0.2.2/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: sparsesvd
+  version: "0.2.2"
+
+source:
+  url: https://pypi.python.org/packages/source/s/sparsesvd/sparsesvd-0.2.2.tar.gz
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - python==3.6.6
+    - setuptools
+    - numpy
+    - scipy
+    - cython
+  build:
+#    - make
+#    - m4
+#    - gcc
+#    - autoconf
+##    - autoconf-archive
+#    - pkg-config
+#    - flex
+#    - ant
+#    - graphviz
+  run:
+    -  libgcc
+#    -  geos
+#    -  proj4
+#    -  json-c
+#    -  libxml2
+#    -  postgresql >=9.1
+
+about:
+  home: https://pypi.org/project/sparsesvd/
+  license: BSD

--- a/environment.yml
+++ b/environment.yml
@@ -144,5 +144,6 @@ dependencies:
   - twisted=17.5.0=py36_0
   - zope=1.0=py36_0
   - link-grammar-minisat-bundled=5.4.4=0
+  - sparsesvd=0.2.2=0
 prefix: /home/obaskov/anaconda3/envs/ull
 

--- a/tests/test_grammartester.py
+++ b/tests/test_grammartester.py
@@ -73,7 +73,7 @@ class GrammarTesterTestCase(unittest.TestCase):
         self.assertEqual(88, pm.sentences)
 
 
-    # @unittest.skip
+    @unittest.skip
     def test_parseability(self):
         """ Test poc-english corpus with poc-turtle dictionary """
         # dict = "poc-turtle"
@@ -98,7 +98,7 @@ class GrammarTesterTestCase(unittest.TestCase):
         self.assertEqual("2.46%", pm.parseability_str(pm).strip())
         self.assertEqual("90.91%", pm.completely_unparsed_str(pm).strip())
 
-    # @unittest.skip
+    @unittest.skip
     def test_parseability_multi_file(self):
         """ Test poc-english corpus with poc-turtle dictionary """
         # dict = "poc-turtle"

--- a/tests/test_grammartester.py
+++ b/tests/test_grammartester.py
@@ -73,7 +73,7 @@ class GrammarTesterTestCase(unittest.TestCase):
         self.assertEqual(88, pm.sentences)
 
 
-    @unittest.skip
+    # @unittest.skip
     def test_parseability(self):
         """ Test poc-english corpus with poc-turtle dictionary """
         # dict = "poc-turtle"
@@ -98,7 +98,7 @@ class GrammarTesterTestCase(unittest.TestCase):
         self.assertEqual("2.46%", pm.parseability_str(pm).strip())
         self.assertEqual("90.91%", pm.completely_unparsed_str(pm).strip())
 
-    @unittest.skip
+    # @unittest.skip
     def test_parseability_multi_file(self):
         """ Test poc-english corpus with poc-turtle dictionary """
         # dict = "poc-turtle"
@@ -138,9 +138,11 @@ class GrammarTesterTestCase(unittest.TestCase):
         pr = LGInprocParser()
         # pr = LGApiParser()
 
+        # opts |= BIT_EXISTING_DICT
+
         gt = GrammarTester(grmr, tmpl, limit, pr)
-        pm1, pq1 = gt.test(dict, corp1, dest, ref1, opts)
-        pm2, pq2 = gt.test(dict, corp2, dest, ref2, opts)
+        pm1, pq1 = gt.test(dict, corp1, dest, ref1, (opts | BIT_EXISTING_DICT))
+        pm2, pq2 = gt.test(dict, corp2, dest, ref2, (opts | BIT_EXISTING_DICT))
 
         # print(pm.text(pm))
         # print(pq.text(pq))

--- a/tests/test_lgapiparser.py
+++ b/tests/test_lgapiparser.py
@@ -32,8 +32,8 @@ class LGAPITestCase(unittest.TestCase):
 
         self.assertTrue(m1 == m2)
 
-        print(q1.text(q1))
-        print(q2.text(q2))
+        # print(q1.text(q1))
+        # print(q2.text(q2))
 
         self.assertTrue(q1 == q2)
 


### PR DESCRIPTION
Fixed Dockerfile to have en_us.UTF-8 as default locale, squized number of layers in order to minimize image size.
Fixed environment.yml to include `sparsesvd` conda package.
Fixed unit tests to be working smoothly in test environment.