### PR TITLE
LGParseError "Number of sentences in corpus and reference files missmatch".

### DIFF
--- a/notebooks/GCB-LG-E-clean-MWC=1-MSL=10-2019-02-17_LGParseError.ipynb
+++ b/notebooks/GCB-LG-E-clean-MWC=1-MSL=10-2019-02-17_LGParseError.ipynb
@@ -1,0 +1,619 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Gutenberg Children Books `2019-02-17` MSL=10 `LGParseError with 20 clusters`\n",
+    "\n",
+    "**LG-E-clean corpus, ALE clustering, 2000/1000/500/50/20 clusters, server 94.130.238.118  \n",
+    "trash filter off, `min_word_count = 1`, `max_sentence_length' = 10`**  \n",
+    " \n",
+    "This notebook is shared as static [GCB-LG-E-clean-ALE-MWC=1-MSL=10-2019-02-17_LGParseError.html](http://langlearn.singularitynet.io/data/clustering_2019/html/GCB-LG-E-clean-ALE-MWC=1-MSL=10-2019-02-17_LGParseError.html).  \n",
+    "Output data shared via [GCB-LG-E-clean-ALE-MWC=1-MSL=10-2019-02-17_LGParseError](http://langlearn.singularitynet.io/data/clustering_2019/GCB-LG-E-clean-ALE-MWC=1-MSL=10-2019-02-17_LGParseError) directory.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T11:17:09.497997Z",
+     "start_time": "2019-02-17T11:17:08.723642Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-02-17 11:17:09 UTC :: module_path: /home/obaskov/94/language-learning\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os, sys, time\n",
+    "module_path = os.path.abspath(os.path.join('..'))\n",
+    "if module_path not in sys.path: sys.path.append(module_path)\n",
+    "from src.grammar_learner.utl import UTC, test_stats\n",
+    "from src.grammar_learner.read_files import check_dir, check_corpus\n",
+    "from src.grammar_learner.write_files import list2file\n",
+    "from src.grammar_learner.widgets import html_table\n",
+    "from src.grammar_learner.pqa_table import table_rows, params, wide_rows\n",
+    "tmpath = module_path + '/tmp/'\n",
+    "check_dir(tmpath, True, 'none')\n",
+    "start = time.time()\n",
+    "runs = (1,1)\n",
+    "print(UTC(), ':: module_path:', module_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Corpus test settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T11:17:09.506862Z",
+     "start_time": "2019-02-17T11:17:09.499755Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-02-17 11:17:09 UTC \n",
+      " /home/obaskov/94/language-learning/output/GCB-LG-E-clean-MWC=1-MSL=10-2019-02-17\n"
+     ]
+    }
+   ],
+   "source": [
+    "corpus = 'GCB' # 'Gutenberg-Children-Books-Caps' \n",
+    "dataset = 'LG-E-clean'\n",
+    "kwargs = {\n",
+    "    'max_sentence_length'   :   10  ,\n",
+    "    'max_unparsed_words'    :   0   ,\n",
+    "    'left_wall'     :   ''          ,\n",
+    "    'period'        :   False       ,\n",
+    "    'context'       :   1           ,\n",
+    "    'min_word_count':   1           ,\n",
+    "    'word_space'    :   'sparse'    ,\n",
+    "    'clustering'    :   ['agglomerative', 'ward'],\n",
+    "    'clustering_metric' : ['silhouette', 'cosine'],\n",
+    "    'cluster_range' :   2000        ,   # 2000/1000/500/50/20\n",
+    "    'top_level'     :   0.01        ,\n",
+    "    'grammar_rules' :   2           ,\n",
+    "    'max_disjuncts' :   1000000     ,   # off\n",
+    "    'stop_words'    :   []          ,\n",
+    "    'tmpath'        :   tmpath      ,\n",
+    "    'verbose'       :   'log+'      ,\n",
+    "    'template_path' :   'poc-turtle',\n",
+    "    'linkage_limit' :   1000        }\n",
+    "rp = module_path + '/data/' + corpus + '/LG-E-clean/GCB-LG-English-clean.ull'\n",
+    "cp = rp  # corpus path = reference_path\n",
+    "runs = (1,1)\n",
+    "out_dir = module_path + '/output/' + 'GCB-LG-E-clean-MWC=1-MSL=10-' + str(UTC())[:10]\n",
+    "print(UTC(), '\\n', out_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tests: `min_word_count = 1`;  2000/1000/500/50/20 clusters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Passed tests: 2000/1000/500/50 clusters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T12:51:32.491497Z",
+     "start_time": "2019-02-17T11:17:09.508752Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "table = []\n",
+    "kwargs['cluster_range'] = 2000\n",
+    "line = [['ALE2000', corpus, dataset, 0, 0, 'none']]\n",
+    "a, _, header, log, rules = wide_rows(line, out_dir, cp, rp, runs, **kwargs)\n",
+    "header[0] = 'Cell'\n",
+    "table.extend(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T12:51:32.502593Z",
+     "start_time": "2019-02-17T12:51:32.495207Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><td>Cell</td><td>Corpus</td><td>Parsing</td><td>Space</td><td>Linkage</td><td>Affinity</td><td>G12n</td><td>Threshold</td><td>Rules</td><td>MWC</td><td>NN</td><td>SI</td><td>PA</td><td>PQ</td><td>F1</td><td>Top 5 cluster sizes</td></tr><tr><td>ALE2000</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>2000</td><td>1</td><td>---</td><td>0.0</td><td>52%</td><td>47%</td><td>0.53</td><td>[1547, 343, 294, 233, 204]</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cleaned dictionary: 13104 words, grammar learn time: 00:55:10, grammar test time: 00:39:12\n"
+     ]
+    }
+   ],
+   "source": [
+    "display(html_table([header] + a)); print(test_stats(log))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T14:15:27.746526Z",
+     "start_time": "2019-02-17T12:51:32.504839Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "kwargs['cluster_range'] = 1000\n",
+    "line = [['ALE1000', corpus, dataset, 0, 0, 'none']]\n",
+    "a, _, h, log, rules = wide_rows(line, out_dir, cp, rp, runs, **kwargs)\n",
+    "table.extend(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T14:15:27.751961Z",
+     "start_time": "2019-02-17T14:15:27.748198Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><td>Cell</td><td>Corpus</td><td>Parsing</td><td>Space</td><td>Linkage</td><td>Affinity</td><td>G12n</td><td>Threshold</td><td>Rules</td><td>MWC</td><td>NN</td><td>SI</td><td>PA</td><td>PQ</td><td>F1</td><td>Top 5 cluster sizes</td></tr><tr><td>ALE1000</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>1000</td><td>1</td><td>---</td><td>0.0</td><td>57%</td><td>47%</td><td>0.53</td><td>[2294, 513, 348, 343, 330]</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cleaned dictionary: 13104 words, grammar learn time: 00:37:29, grammar test time: 00:46:25\n"
+     ]
+    }
+   ],
+   "source": [
+    "display(html_table([header] + a)); print(test_stats(log))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T15:38:19.781455Z",
+     "start_time": "2019-02-17T14:15:27.753149Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "kwargs['cluster_range'] = 500\n",
+    "line = [['ALE500', corpus, dataset, 0, 0, 'none']]\n",
+    "a, _, header, log, rules = wide_rows(line, out_dir, cp, rp, runs, **kwargs)\n",
+    "header[0] = 'Cell'\n",
+    "table.extend(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T15:38:19.788958Z",
+     "start_time": "2019-02-17T15:38:19.784010Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><td>Cell</td><td>Corpus</td><td>Parsing</td><td>Space</td><td>Linkage</td><td>Affinity</td><td>G12n</td><td>Threshold</td><td>Rules</td><td>MWC</td><td>NN</td><td>SI</td><td>PA</td><td>PQ</td><td>F1</td><td>Top 5 cluster sizes</td></tr><tr><td>ALE500</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>500</td><td>1</td><td>---</td><td>0.0</td><td>61%</td><td>49%</td><td>0.53</td><td>[3141, 653, 453, 372, 371]</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cleaned dictionary: 13104 words, grammar learn time: 00:29:58, grammar test time: 00:52:52\n"
+     ]
+    }
+   ],
+   "source": [
+    "display(html_table([header] + a)); print(test_stats(log))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T15:38:19.901262Z",
+     "start_time": "2019-02-17T15:38:19.791233Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><td>Cell</td><td>Corpus</td><td>Parsing</td><td>Space</td><td>Linkage</td><td>Affinity</td><td>G12n</td><td>Threshold</td><td>Rules</td><td>MWC</td><td>NN</td><td>SI</td><td>PA</td><td>PQ</td><td>F1</td><td>Top 5 cluster sizes</td></tr><tr><td>ALE2000</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>2000</td><td>1</td><td>---</td><td>0.0</td><td>52%</td><td>47%</td><td>0.53</td><td>[1547, 343, 294, 233, 204]</td></tr><tr><td>ALE1000</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>1000</td><td>1</td><td>---</td><td>0.0</td><td>57%</td><td>47%</td><td>0.53</td><td>[2294, 513, 348, 343, 330]</td></tr><tr><td>ALE500</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>500</td><td>1</td><td>---</td><td>0.0</td><td>61%</td><td>49%</td><td>0.53</td><td>[3141, 653, 453, 372, 371]</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(html_table([header] + table))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T15:38:19.977190Z",
+     "start_time": "2019-02-17T15:38:19.903185Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-02-17 15:38:19 UTC :: 2000/100/500 finished, elapsed 4.4 hours\n",
+      "Results saved to /home/obaskov/94/language-learning/output/GCB-LG-E-clean-MWC=1-MSL=10-2019-02-17/all_tests_table.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(UTC(), ':: 2000/100/500 finished, elapsed', str(round((time.time()-start)/3600.0, 1)), 'hours')\n",
+    "table_str = list2file(table, out_dir + '/all_tests_table.txt')\n",
+    "print('Results saved to', out_dir + '/all_tests_table.txt')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T18:42:59.623036Z",
+     "start_time": "2019-02-17T15:38:19.980973Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "kwargs['cluster_range'] = 50\n",
+    "line = [['ALE50', corpus, dataset, 0, 0, 'none']]\n",
+    "a, _, h, log, rules = wide_rows(line, out_dir, cp, rp, runs, **kwargs)\n",
+    "table.extend(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T18:42:59.629194Z",
+     "start_time": "2019-02-17T18:42:59.624697Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><td>Cell</td><td>Corpus</td><td>Parsing</td><td>Space</td><td>Linkage</td><td>Affinity</td><td>G12n</td><td>Threshold</td><td>Rules</td><td>MWC</td><td>NN</td><td>SI</td><td>PA</td><td>PQ</td><td>F1</td><td>Top 5 cluster sizes</td></tr><tr><td>ALE50</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>50</td><td>1</td><td>---</td><td>0.0</td><td>89%</td><td>58%</td><td>0.58</td><td>[6402, 2893, 1702, 899, 292]</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cleaned dictionary: 13104 words, grammar learn time: 00:24:45, grammar test time: 02:39:54\n"
+     ]
+    }
+   ],
+   "source": [
+    "display(html_table([header] + a)); print(test_stats(log))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T18:42:59.772346Z",
+     "start_time": "2019-02-17T18:42:59.630743Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><td>Cell</td><td>Corpus</td><td>Parsing</td><td>Space</td><td>Linkage</td><td>Affinity</td><td>G12n</td><td>Threshold</td><td>Rules</td><td>MWC</td><td>NN</td><td>SI</td><td>PA</td><td>PQ</td><td>F1</td><td>Top 5 cluster sizes</td></tr><tr><td>ALE2000</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>2000</td><td>1</td><td>---</td><td>0.0</td><td>52%</td><td>47%</td><td>0.53</td><td>[1547, 343, 294, 233, 204]</td></tr><tr><td>ALE1000</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>1000</td><td>1</td><td>---</td><td>0.0</td><td>57%</td><td>47%</td><td>0.53</td><td>[2294, 513, 348, 343, 330]</td></tr><tr><td>ALE500</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>500</td><td>1</td><td>---</td><td>0.0</td><td>61%</td><td>49%</td><td>0.53</td><td>[3141, 653, 453, 372, 371]</td></tr><tr><td>ALE50</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>50</td><td>1</td><td>---</td><td>0.0</td><td>89%</td><td>58%</td><td>0.58</td><td>[6402, 2893, 1702, 899, 292]</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(html_table([header] + table))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-17T18:42:59.856377Z",
+     "start_time": "2019-02-17T18:42:59.774526Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-02-17 18:42:59 UTC :: 2000/1000/500/50 finished, elapsed 7.4 hours\n",
+      "Results saved to /home/obaskov/94/language-learning/output/GCB-LG-E-clean-MWC=1-MSL=10-2019-02-17/all_tests_table.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(UTC(), ':: 2000/1000/500/50 finished, elapsed', str(round((time.time()-start)/3600.0, 1)), 'hours')\n",
+    "table_str = list2file(table, out_dir + '/all_tests_table.txt')\n",
+    "print('Results saved to', out_dir + '/all_tests_table.txt')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test failed with 20 clusters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-20T20:28:08.185230Z",
+     "start_time": "2019-02-17T18:42:59.859714Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "ename": "LGParseError",
+     "evalue": "Number of sentences in corpus and reference files missmatch. Reference file '/home/obaskov/94/language-learning/data/GCB/LG-E-clean/GCB-LG-English-clean.ull' does not match its corpus counterpart 104341 != 104340.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mLGParseError\u001b[0m                              Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-15-d1ec7b15a3c4>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'cluster_range'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m20\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mline\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'ALE20'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcorpus\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdataset\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'none'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mh\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlog\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrules\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mwide_rows\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mout_dir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mruns\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mtable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mextend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/94/language-learning/src/grammar_learner/pqa_table.py\u001b[0m in \u001b[0;36mwide_rows\u001b[0;34m(lines, out_dir, cp, rp, runs, **kwargs)\u001b[0m\n\u001b[1;32m    427\u001b[0m                 \u001b[0;32mfor\u001b[0m \u001b[0mk\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mruns\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    428\u001b[0m                     a, f1, precision, q = pqa_meter(re['grammar_file'],\n\u001b[0;32m--> 429\u001b[0;31m                                                     og, cp, rp, **kwargs)\n\u001b[0m\u001b[1;32m    430\u001b[0m                     \u001b[0mpa\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    431\u001b[0m                     \u001b[0mpq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mq\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/94/language-learning/src/grammar_learner/pqa_table.py\u001b[0m in \u001b[0;36mpqa_meter\u001b[0;34m(dict_path, op, cp, rp, **kwargs)\u001b[0m\n\u001b[1;32m    112\u001b[0m                                              \u001b[0mdict_path\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mgrammar_path\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    113\u001b[0m                                              \u001b[0mtemplate_path\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlinkage_limit\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 114\u001b[0;31m                                              options, reference_path)\n\u001b[0m\u001b[1;32m    115\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mfloat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpa\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfloat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mf1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfloat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mprecision\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfloat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrecall\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    116\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/94/language-learning/src/grammar_tester/grammartester.py\u001b[0m in \u001b[0;36mtest_grammar\u001b[0;34m(corpus_path, output_path, dict_path, grammar_path, template_path, linkage_limit, options, reference_path, timeout)\u001b[0m\n\u001b[1;32m    372\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    373\u001b[0m     \u001b[0;31m# pm, pq = gt.test(dict_path, corpus_path, output_path, reference_path, options, None)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 374\u001b[0;31m     \u001b[0mpm\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpq\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtest\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdict_path\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcorpus_path\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moutput_path\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreference_path\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moptions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mTextProgress\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    375\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    376\u001b[0m     \u001b[0;32mreturn\u001b[0m\u001b[0;31m \u001b[0m\u001b[0;31m\\\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/94/language-learning/src/grammar_tester/grammartester.py\u001b[0m in \u001b[0;36mtest\u001b[0;34m(self, dict_path, corpus_path, output_path, reference_path, options, progress)\u001b[0m\n\u001b[1;32m    327\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_options\u001b[0m \u001b[0;34m&=\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;34m~\u001b[0m\u001b[0mBIT_DPATH_CREATE\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    328\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 329\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_on_dict_file\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdict_path\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparse_args\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    330\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    331\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_parser\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/94/language-learning/src/grammar_tester/grammartester.py\u001b[0m in \u001b[0;36m_on_dict_file\u001b[0;34m(self, dict_file_path, args)\u001b[0m\n\u001b[1;32m    224\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    225\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0misfile\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcorp_path\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 226\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_on_corpus_file\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcorp_path\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mdest_path\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlang_path\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    227\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    228\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0misdir\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcorp_path\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/94/language-learning/src/grammar_tester/grammartester.py\u001b[0m in \u001b[0;36m_on_corpus_file\u001b[0;34m(self, corpus_file_path, args)\u001b[0m\n\u001b[1;32m    181\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    182\u001b[0m         file_metrics, file_quality = self._parser.parse(dict_path, corpus_file_path, out_file,\n\u001b[0;32m--> 183\u001b[0;31m                                                         ref_file, self._options, self._progress)\n\u001b[0m\u001b[1;32m    184\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    185\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_options\u001b[0m \u001b[0;34m&\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mBIT_SEP_STAT\u001b[0m \u001b[0;34m|\u001b[0m \u001b[0mBIT_OUTPUT\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0mBIT_SEP_STAT\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/94/language-learning/src/grammar_tester/lginprocparser.py\u001b[0m in \u001b[0;36mparse\u001b[0;34m(self, dict_path, corpus_path, output_path, ref_file, options, progress)\u001b[0m\n\u001b[1;32m    298\u001b[0m                 \u001b[0;31m# Take an action depending on the output format specified by 'options'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    299\u001b[0m                 ret_metrics, ret_quality = self._handle_stream_output(raw.decode(\"utf-8-sig\"), options,\n\u001b[0;32m--> 300\u001b[0;31m                                                                       out_stream, ref_file)\n\u001b[0m\u001b[1;32m    301\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    302\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mprogress\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/94/language-learning/src/grammar_tester/lginprocparser.py\u001b[0m in \u001b[0;36m_handle_stream_output\u001b[0;34m(self, text, options, out_stream, ref_path)\u001b[0m\n\u001b[1;32m    159\u001b[0m                     raise LGParseError(\"Number of sentences in corpus and reference files missmatch. \"\n\u001b[1;32m    160\u001b[0m                                        \u001b[0;34m\"Reference file '{}' does not match \"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 161\u001b[0;31m                                        \"its corpus counterpart {} != {}.\".format(ref_path, len_ref, len_par))\n\u001b[0m\u001b[1;32m    162\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    163\u001b[0m             \u001b[0msentence_count\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mLGParseError\u001b[0m: Number of sentences in corpus and reference files missmatch. Reference file '/home/obaskov/94/language-learning/data/GCB/LG-E-clean/GCB-LG-English-clean.ull' does not match its corpus counterpart 104341 != 104340."
+     ]
+    }
+   ],
+   "source": [
+    "%%capture\n",
+    "kwargs['cluster_range'] = 20\n",
+    "line = [['ALE20', corpus, dataset, 0, 0, 'none']]\n",
+    "a, _, h, log, rules = wide_rows(line, out_dir, cp, rp, runs, **kwargs)\n",
+    "table.extend(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-20T20:28:08.190085Z",
+     "start_time": "2019-02-20T20:28:08.186717Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "display(html_table([header] + a)); print(test_stats(log))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Test with 20 clusters failed in ~74 hours, finished 20:28:08 2019-02-20"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Save results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-20T20:28:08.365554Z",
+     "start_time": "2019-02-20T20:28:08.191495Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><td>Cell</td><td>Corpus</td><td>Parsing</td><td>Space</td><td>Linkage</td><td>Affinity</td><td>G12n</td><td>Threshold</td><td>Rules</td><td>MWC</td><td>NN</td><td>SI</td><td>PA</td><td>PQ</td><td>F1</td><td>Top 5 cluster sizes</td></tr><tr><td>ALE2000</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>2000</td><td>1</td><td>---</td><td>0.0</td><td>52%</td><td>47%</td><td>0.53</td><td>[1547, 343, 294, 233, 204]</td></tr><tr><td>ALE1000</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>1000</td><td>1</td><td>---</td><td>0.0</td><td>57%</td><td>47%</td><td>0.53</td><td>[2294, 513, 348, 343, 330]</td></tr><tr><td>ALE500</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>500</td><td>1</td><td>---</td><td>0.0</td><td>61%</td><td>49%</td><td>0.53</td><td>[3141, 653, 453, 372, 371]</td></tr><tr><td>ALE50</td><td>GCB</td><td>LG-E-clean</td><td>cALWEd</td><td>ward</td><td>euclidean</td><td>none</td><td>---</td><td>50</td><td>1</td><td>---</td><td>0.0</td><td>89%</td><td>58%</td><td>0.58</td><td>[6402, 2893, 1702, 899, 292]</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(html_table([header] + table))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-02-20T20:28:08.443425Z",
+     "start_time": "2019-02-20T20:28:08.368226Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-02-20 20:28:08 UTC :: finished, elapsed 81.2 hours\n",
+      "Results saved to /home/obaskov/94/language-learning/output/GCB-LG-E-clean-MWC=1-MSL=10-2019-02-17/all_tests_table.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(UTC(), ':: finished, elapsed', str(round((time.time()-start)/3600.0, 1)), 'hours')\n",
+    "table_str = list2file(table, out_dir + '/all_tests_table.txt')\n",
+    "print('Results saved to', out_dir + '/all_tests_table.txt')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Test with 20 clusters might take several days to fulfil or fail... \n",
+    "Please check results in [all_tests_table.txt](http://langlearn.singularitynet.io/data/clustering_2019/GCB-LG-E-clean-ALE-MWC=1-MSL=10-2019-02-17/all_tests_table.txt) file.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [default]",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
4 of 5 tests pass OK.  
The 5th (notebook sell 15) crashes with LGParseError: Number of sentences in corpus and reference files missmatch. Reference file '/home/obaskov/94/language-learning/data/GCB/LG-E-clean/GCB-LG-English-clean.ull' does not match its corpus counterpart 104341 != 104340.   
The corpus is extracted from reference file in all the 5 tests.  

Static html copy of the notebook -- [GCB-LG-E-clean-ALE-MWC=1-MSL=10-2019-02-17_LGParseError.html](http://langlearn.singularitynet.io/data/clustering_2019/html/GCB-LG-E-clean-ALE-MWC=1-MSL=10-2019-02-17_LGParseError.html), error in cell 15.  
The faulty grammar directory -- [GCB-LG-E-clean-ALE-MWC=1-MSL=10-2019-02-17_LGParseError/GCB_LG-E-clean_cALWEd_no-gen_20c/](http://langlearn.singularitynet.io/data/clustering_2019/GCB-LG-E-clean-ALE-MWC=1-MSL=10-2019-02-17_LGParseError/GCB_LG-E-clean_cALWEd_no-gen_20c/)