### PR TITLE
filtering sentences with any double-quotes

### DIFF
--- a/src/parse_evaluator/parse_evaluator.py
+++ b/src/parse_evaluator/parse_evaluator.py
@@ -92,11 +92,12 @@ def Evaluate_Parses(test_parses, test_sents, ref_parses, ref_sents, verbose, ign
         false_pos = 0
 
         # when filter is active, ignore sentence if they're not equal
-        # or it contains internal quotes (for dialogue sentences)
+        # or it contains any quotes (for dialogue sentences)
         if filter:
             joint_test_sent = " ".join(test_sent)
             joint_ref_sent = " ".join(ref_sent)
-            count_quotes = ref_sent[1:-1].count('"')
+            #count_quotes = ref_sent[1:-1].count('"') # only internal quotes
+            count_quotes = ref_sent.count('"') # any quotes
             if joint_ref_sent.lower() != joint_test_sent.lower() or count_quotes > 0:
                 filtered_sents += 1
                 continue


### PR DESCRIPTION
Option in parse-evaluator filters sentences that contain any number of double quotes in them, according to issue: https://github.com/singnet/language-learning/issues/181