### PR TITLE
Compare tokenization

### DIFF
--- a/src/cli_scripts/parse-evaluator
+++ b/src/cli_scripts/parse-evaluator
@@ -33,16 +33,17 @@ def main(argv):
         # word1 # word2
         ...
 
-        Usage: parse_evaluator -r <reffile> [-t <testfile>] [-v] [-i] [-s] [-z] [-a]
+        Usage: parse_evaluator -r <reffile> -t <testfile> [-v] [-i] [-s] [-z] [-a] [-o]
 
         testfile        file with parses to evaluate
-        goldfile        file with reference (gold standard) parses
+        reffile         file with reference (gold standard) parses
         -v              Verbosity level options: [none, debug, info, warning, error, critical]
         -i              ignore LEFT-WALL and end-of-sentence dot, if any
         -a              use alternative parse_evaluator
         -s              evaluate sequential parses (only in alternative evaluator)
         -z              evaluate random parses (only in alternative evaluator)
         -f              filter sentences not matching in ref and test, or have internal dialogue (only in alternative)
+        -o              compare tokenization between two given parse files. Output file with diffs
 
     """
     test_file = ''
@@ -54,16 +55,17 @@ def main(argv):
     random = False
     alternative_parser = False
     filter_sentences = False
+    compare_tokenization = False
 
     try:
         app_name = str(os.path.split(__file__)[1]).split(".")[0]
 
-        opts, args = getopt.getopt(argv, "ht:r:v:iszaf", ["test=", "reference=", "verbosity=", "ignore", "sequential",
-                                                         "random", "alternative", "filter"])
+        opts, args = getopt.getopt(argv, "ht:r:v:iszafo", ["test=", "reference=", "verbosity=", "ignore", "sequential",
+                                                         "random", "alternative", "filter", "tokenization"])
 
         for opt, arg in opts:
             if opt == '-h':
-                print("Usage: ./parse_evaluator.py -r <reffile> -t <testfile> [-v] [-i] [-s] [-z] [-a] [-f]")
+                print("Usage: ./parse_evaluator.py -r <reffile> -t <testfile> [-v] [-i] [-s] [-z] [-a] [-f] [-o]")
                 sys.exit()
             elif opt in ("-t", "--test"):
                 test_file = arg
@@ -87,9 +89,11 @@ def main(argv):
                 alternative_parser = True
             elif opt in ("-f", "--filter"):
                 filter_sentences = True
+            elif opt in ("-o", "--tokenization"):
+                compare_tokenization = True
 
     except getopt.GetoptError:
-        print("Usage: ./parse_evaluator.py -r <reffile> [-t <testfile>] [-v] [-i] [-s] [-z] [-a] [-f]")
+        print("Usage: ./parse_evaluator.py -r <reffile> [-t <testfile>] [-v] [-i] [-s] [-z] [-a] [-f] [-o]")
         sys.exit(2)
 
 
@@ -115,7 +119,7 @@ def main(argv):
             raise EvalError("Error: Incorrect test_file.")
 
         if alternative_parser:
-            Evaluate_Alternative(ref_file, test_file, verbose, ignore_wall, sequential, random, filter_sentences)
+            Evaluate_Alternative(ref_file, test_file, verbose, ignore_wall, sequential, random, filter_sentences, compare_tokenization)
 
         else:
             compare_ull_files(test_file, ref_file, verbose, ignore_wall)

--- a/src/parse_evaluator/parse_evaluator.py
+++ b/src/parse_evaluator/parse_evaluator.py
@@ -204,7 +204,9 @@ def Make_Random(sents):
 def Compare_Tokenization(ref_sentences, test_sentences):
     """
         Compares tokenization differences between parse files. Ignores caps
-        and LG-unparsed (bracketed) tokens
+        and LG-unparsed (bracketed) tokens.
+        Writes tok_diff.txt file with sentences that have different tokenization, and
+        shows the different tokens
     """
     with open("tok_diff.txt", "w") as ft:
         for ref_sent, test_sent in zip(ref_sentences, test_sentences):
@@ -223,11 +225,10 @@ def Compare_Tokenization(ref_sentences, test_sentences):
             if new_ref != new_test:
                 set_ref = set(new_ref)
                 set_test = set(new_test)
-                ft.write("Sentence Differs:\n{}\nin tokens:{}---{}\n".format(" ".join(ref_sent), set_ref - set_test, set_test - set_ref))
+                ft.write("Sentence Differs:\n{}\nin tokens:{}<--->{}\n".format(" ".join(ref_sent), set_ref - set_test, set_test - set_ref))
 
-def Evaluate_Alternative(ref_file, test_file, verbose, ignore_WALL, sequential, random_flag, filter_sentences):
+def Evaluate_Alternative(ref_file, test_file, verbose, ignore_WALL, sequential, random_flag, filter_sentences, compare_tokenization):
 
-    compare_tokenization=True # temporarily run comparison always
     ref_data = Load_File(ref_file)
     ref_parses, ref_sents = Get_Parses(ref_data) 
     if sequential:

--- a/src/parse_evaluator/parse_evaluator.py
+++ b/src/parse_evaluator/parse_evaluator.py
@@ -221,7 +221,9 @@ def Compare_Tokenization(ref_sentences, test_sentences):
                     token_test = token_test[1:-1]
                 new_test.append(token_test)
             if new_ref != new_test:
-                ft.write("Sents Differ:\n{}\n{}\n".format(new_ref, new_test))
+                set_ref = set(new_ref)
+                set_test = set(new_test)
+                ft.write("Sentence Differs:\n{}\nin tokens:{}---{}\n".format(" ".join(ref_sent), set_ref - set_test, set_test - set_ref))
 
 def Evaluate_Alternative(ref_file, test_file, verbose, ignore_WALL, sequential, random_flag, filter_sentences):
 

--- a/src/parse_evaluator/parse_evaluator.py
+++ b/src/parse_evaluator/parse_evaluator.py
@@ -201,8 +201,31 @@ def Make_Random(sents):
 
     return random_parses
 
+def Compare_Tokenization(ref_sentences, test_sentences):
+    """
+        Compares tokenization differences between parse files. Ignores caps
+        and LG-unparsed (bracketed) tokens
+    """
+    with open("tok_diff.txt", "w") as ft:
+        for ref_sent, test_sent in zip(ref_sentences, test_sentences):
+            new_ref = []
+            new_test = []
+            for token_ref in ref_sent:
+                token_ref = token_ref.lower()
+                if token_ref[0] == "[" and token_ref[-1] == "]":
+                    token_ref = token_ref[1:-1]
+                new_ref.append(token_ref)
+            for token_test in test_sent:
+                token_test = token_test.lower()
+                if token_test[0] == "[" and token_test[-1] == "]":
+                    token_test = token_test[1:-1]
+                new_test.append(token_test)
+            if new_ref != new_test:
+                ft.write("Sents Differ:\n{}\n{}\n".format(new_ref, new_test))
+
 def Evaluate_Alternative(ref_file, test_file, verbose, ignore_WALL, sequential, random_flag, filter_sentences):
 
+    compare_tokenization=True # temporarily run comparison always
     ref_data = Load_File(ref_file)
     ref_parses, ref_sents = Get_Parses(ref_data) 
     if sequential:
@@ -216,4 +239,7 @@ def Evaluate_Alternative(ref_file, test_file, verbose, ignore_WALL, sequential, 
         test_parses, test_sents = Get_Parses(test_data) 
     if len(test_parses) != len(ref_parses):
         sys.exit("ERROR: Number of parses differs in files: ", len(test_parses), ", ", len(ref_parses))
+    if compare_tokenization:
+        Compare_Tokenization(ref_sents, test_sents)
+        return # exit
     Evaluate_Parses(test_parses, test_sents, ref_parses, ref_sents, verbose, ignore_WALL, filter_sentences)

--- a/src/parse_evaluator/parse_evaluator.py
+++ b/src/parse_evaluator/parse_evaluator.py
@@ -243,6 +243,7 @@ def Evaluate_Alternative(ref_file, test_file, verbose, ignore_WALL, sequential, 
     if len(test_parses) != len(ref_parses):
         sys.exit("ERROR: Number of parses differs in files: ", len(test_parses), ", ", len(ref_parses))
     if compare_tokenization:
+        print("Comparing tokenization only...")
         Compare_Tokenization(ref_sents, test_sents)
         return # exit
     Evaluate_Parses(test_parses, test_sents, ref_parses, ref_sents, verbose, ignore_WALL, filter_sentences)


### PR DESCRIPTION
Added functionality to parse-evaluator to compare the tokenization between the two given parse files.
Ignoring capitalization and unparsed words (bracketed words "[example]), the algorithm checks if there are tokenization differences, and logs those in file "tok_diff.txt".