### PR TITLE
parse-evaluator fixes for issue #226

### DIFF
--- a/src/cli_scripts/parse-evaluator
+++ b/src/cli_scripts/parse-evaluator
@@ -40,6 +40,7 @@ def main(argv):
         testfile        file with parses to evaluate
         reffile         file with reference (gold standard) parses
         -v              Verbosity level options: [none, debug, info, warning, error, critical]
+        -z              File logging level options: [none, debug, info, warning, error, critical]
         -i              ignore LEFT-WALL and end-of-sentence dot, if any
         -a              use alternative parse_evaluator
         -s              evaluate sequential parses (only in alternative evaluator)
@@ -55,6 +56,7 @@ def main(argv):
     out_path = None
     verbose = False
     verbosity_level = logging.WARNING
+    logging_level   = logging.NOTSET
     ignore_wall = False
     sequential = False
     random = False
@@ -67,15 +69,13 @@ def main(argv):
     try:
         app_name = str(os.path.split(__file__)[1]).split(".")[0]
 
-        opts, args = getopt.getopt(argv, "ht:r:O:v:iszafoTS", ["test=", "reference=", "output=", "verbosity=", "ignore",
+        opts, args = getopt.getopt(argv, "ht:r:O:v:iszafoTSw:", ["test=", "reference=", "output=", "verbosity=", "ignore",
                                                              "sequential", "random", "alternative", "filter",
                                                              "tokenization", "strict-tokenization",
-                                                             "ignore-sent-mismatch"])
+                                                             "ignore-sent-mismatch", "logging"])
 
         for opt, arg in opts:
             if opt == '-h':
-                # print("Usage: ./parse_evaluator.py -r <reffile> -t <testfile> [-O <output-path>] [-v] [-i] [-s] [-z] "
-                #       "[-a] [-f] [-o]")
                 print(main.__doc__)
                 sys.exit()
             elif opt in ("-t", "--test"):
@@ -92,6 +92,13 @@ def main(argv):
 
                 verbosity_level = VERBOSITY_OPTIONS[verb_key]
                 verbose = verbosity_level < logging.WARNING
+            elif opt in ("-w", "--logging"):
+                log_key = strip_quotes(arg)
+
+                if log_key not in VERBOSITY_OPTIONS.keys():
+                    raise getopt.GetoptError("Wrong logging argument value: ()".format(log_key))
+
+                logging_level = VERBOSITY_OPTIONS[log_key]
             elif opt in ("-i", "--ignore"):
                 ignore_wall = True
                 options |= (BIT_NO_LWALL | BIT_NO_PERIOD)
@@ -118,10 +125,10 @@ def main(argv):
                 options |= BIT_IGNORE_SENT_MISMATCH
 
     except getopt.GetoptError:
-        print("Usage: ./parse_evaluator.py -r <reffile> [-t <testfile>] [-v] [-i] [-s] [-z] [-a] [-f] [-o]")
+        print(main.__doc__)
         sys.exit(2)
 
-    setup_logging(verbosity_level, logging.NOTSET, os.environ["PWD"] + "/" + app_name + ".log", "w")
+    setup_logging(verbosity_level, logging_level, f"{os.environ['PWD']}/{app_name}.log", "w")
 
     logger = logging.getLogger(app_name)
 
@@ -169,7 +176,7 @@ def main(argv):
 
     except EvalError as err:
         logger.critical(str(err))
-        logger.debug(traceback.print_exc())
+        # logger.debug(traceback.print_exc())
         return 3
 
     except KeyboardInterrupt:

--- a/src/cli_scripts/parse-evaluator
+++ b/src/cli_scripts/parse-evaluator
@@ -13,7 +13,8 @@ import logging
 import traceback
 
 from ull.common import handle_path_string, strip_quotes, setup_logging, VERBOSITY_OPTIONS, \
-    BIT_NO_LWALL, BIT_ULL_IN, BIT_NO_PERIOD, BIT_FILTER_DIR_SPEECH
+    BIT_NO_LWALL, BIT_ULL_IN, BIT_NO_PERIOD, BIT_FILTER_DIR_SPEECH, BIT_STRICT_TOKENIZATION, \
+    BIT_IGNORE_SENT_MISMATCH
 from ull.grammar_tester import compare_ull_files, EvalError
 from ull.parse_evaluator import Evaluate_Alternative
 
@@ -45,7 +46,9 @@ def main(argv):
         -z              evaluate random parses (only in alternative evaluator)
         -f              filter sentences not matching in ref and test, or have internal dialogue (only in alternative)
         -o              compare tokenization between two given parse files. Output file with diffs.
-
+        -O              output directory path
+        -T              strict tokenization
+        -S              ignore sentences mismatch
     """
     test_file = ''
     ref_file = ''
@@ -64,14 +67,16 @@ def main(argv):
     try:
         app_name = str(os.path.split(__file__)[1]).split(".")[0]
 
-        opts, args = getopt.getopt(argv, "ht:r:O:v:iszafo", ["test=", "reference=", "output=", "verbosity=", "ignore",
+        opts, args = getopt.getopt(argv, "ht:r:O:v:iszafoTS", ["test=", "reference=", "output=", "verbosity=", "ignore",
                                                              "sequential", "random", "alternative", "filter",
-                                                             "tokenization"])
+                                                             "tokenization", "strict-tokenization",
+                                                             "ignore-sent-mismatch"])
 
         for opt, arg in opts:
             if opt == '-h':
-                print("Usage: ./parse_evaluator.py -r <reffile> -t <testfile> [-O <output-path>] [-v] [-i] [-s] [-z] "
-                      "[-a] [-f] [-o]")
+                # print("Usage: ./parse_evaluator.py -r <reffile> -t <testfile> [-O <output-path>] [-v] [-i] [-s] [-z] "
+                #       "[-a] [-f] [-o]")
+                print(main.__doc__)
                 sys.exit()
             elif opt in ("-t", "--test"):
                 test_file = arg
@@ -107,6 +112,10 @@ def main(argv):
                 options |= BIT_FILTER_DIR_SPEECH
             elif opt in ("-o", "--tokenization"):
                 compare_tokenization = True
+            elif opt in ("-T", "--strict-tokenization"):
+                options |= BIT_STRICT_TOKENIZATION
+            elif opt in ("-S", "--ignore-sent-mismatch"):
+                options |= BIT_IGNORE_SENT_MISMATCH
 
     except getopt.GetoptError:
         print("Usage: ./parse_evaluator.py -r <reffile> [-t <testfile>] [-v] [-i] [-s] [-z] [-a] [-f] [-o]")

--- a/src/common/optconst.py
+++ b/src/common/optconst.py
@@ -1,12 +1,11 @@
 
 __all__ = [
-    # 'LG_DICT_PATH',
     'BIT_CAPS', 'BIT_RWALL', 'BIT_STRIP', 'BIT_OUTPUT', 'BIT_ULL_IN', 'BIT_RM_DIR',
     'BIT_OUTPUT_DIAGRAM', 'BIT_OUTPUT_POSTSCRIPT', 'BIT_OUTPUT_CONST_TREE', 'BIT_OUTPUT_ALL',
     'BIT_LG_GR_NAME', 'BIT_DPATH_CREATE', 'BIT_LG_EXE', 'BIT_NO_LWALL', 'BIT_SEP_STAT', 'BIT_LOC_LANG',
     'BIT_PARSE_QUALITY', 'BIT_NO_PERIOD', 'BIT_ULL_NO_LWALL', 'BIT_GRSUBDIR_CREATE', 'BIT_INPUT_TO_LCASE',
     'BIT_EXISTING_DICT', 'BIT_EXCLUDE_TIMEOUTED', 'BIT_EXCLUDE_PANICED', 'BIT_EXCLUDE_EXPLOSION',
-    'BIT_FILTER_DIR_SPEECH', 'get_options'
+    'BIT_FILTER_DIR_SPEECH', 'BIT_STRICT_TOKENIZATION', 'BIT_IGNORE_SENT_MISMATCH', 'get_options'
 ]
 
 # Link Grammar output format constants. If no bits set, ULL defacto format is used.
@@ -42,6 +41,8 @@ BIT_EXCLUDE_PANICED     = (1<<21)           # Exclude linkage(s) from statistics
 BIT_EXCLUDE_EXPLOSION   = (1<<22)           # Exclude linkage(s) from statistics estimation if LG combinatorial
                                             #   explosion is detected.
 BIT_FILTER_DIR_SPEECH   = (1<<23)           # Filter out direct speech.
+BIT_STRICT_TOKENIZATION = (1<<24)           # Ignore tokenization discrepancies when comparing parses
+BIT_IGNORE_SENT_MISMATCH= (1<<25)           # Ignore sentences mismatch when comparing parses
 
 config_options = {
     "keep_caps": (BIT_CAPS, False),
@@ -62,7 +63,9 @@ config_options = {
     "existing_dict_dir": (BIT_EXISTING_DICT, False),
     "exclude_timeouted": (BIT_EXCLUDE_TIMEOUTED, False),
     "exclude_paniced": (BIT_EXCLUDE_PANICED, False),
-    "exclude_explosion": (BIT_EXCLUDE_EXPLOSION, False)
+    "exclude_explosion": (BIT_EXCLUDE_EXPLOSION, False),
+    "strict_tokenization": (BIT_STRICT_TOKENIZATION, False),
+    "ignore_sentence_mismatch": (BIT_IGNORE_SENT_MISMATCH, False)
 }
 
 output_format = {

--- a/src/grammar_tester/artificialparser.py
+++ b/src/grammar_tester/artificialparser.py
@@ -3,7 +3,7 @@ from typing import Tuple, List, Callable
 from ..common.absclient import AbstractProgressClient, AbstractFileParserClient
 from ..common.parsemetrics import ParseQuality, ParseMetrics
 from ..common.optconst import *
-from .parsevaluate import get_parses, load_ull_file, save_parses, eval_parses, \
+from .parsevaluate import load_parses, save_parses, eval_parses, \
     make_sequential, make_random
 
 
@@ -30,7 +30,7 @@ class ArtificialParser(AbstractFileParserClient):
 
         pm: ParseMetrics = ParseMetrics()
 
-        ref_parses = get_parses(load_ull_file(ref_file))
+        ref_parses = load_parses(ref_file)
         test_parses = self.operation(ref_parses, options, **self.kwargs)
         save_parses(test_parses, output_path, options)
 

--- a/src/grammar_tester/lgapiparser.py
+++ b/src/grammar_tester/lgapiparser.py
@@ -8,7 +8,7 @@ from .parsestat import parse_metrics, parse_quality
 from .psparse import parse_postscript, prepare_tokens, get_link_set
 from .lgmisc import get_output_suffix, print_output
 from ..common.absclient import AbstractFileParserClient
-from .parsevaluate import load_ull_file, get_parses
+from .parsevaluate import load_parses
 
 
 __all__ = ['LGApiParser']
@@ -51,12 +51,7 @@ class LGApiParser(AbstractFileParserClient):
 
         try:
             if options & BIT_PARSE_QUALITY and ref_path is not None:
-                try:
-                    data = load_ull_file(ref_path)
-                    ref_parses = get_parses(data, (options & BIT_NO_LWALL) == BIT_NO_LWALL, False)
-
-                except Exception as err:
-                    print("Exception: " + str(err))
+                ref_parses = load_parses(ref_path)
 
             link_line = re.compile(r"\A[0-9].+")
 

--- a/src/grammar_tester/lginprocparser.py
+++ b/src/grammar_tester/lginprocparser.py
@@ -10,7 +10,7 @@ from .psparse import *
 from .parsestat import *
 from ..common.parsemetrics import *
 from .lgmisc import *
-from .parsevaluate import get_parses, load_ull_file, tokenize_sentence, unbox_tokens, EvalError
+from .parsevaluate import load_parses, tokenize_sentence, unbox_tokens, EvalError
 from .lgpcommands import *
 from .linkgrammarver import get_lg_version, get_lg_dict_version
 
@@ -157,13 +157,7 @@ class LGInprocParser(AbstractFileParserClient):
         if not (options & BIT_OUTPUT):
 
             if options & BIT_PARSE_QUALITY and ref_path is not None:
-                data = load_ull_file(ref_path)
-
-                try:
-                    ref_parses = get_parses(data)
-
-                except AssertionError as err:
-                    raise LGParseError(str(err) + "\n\tMake sure '{}' has proper .ull file format.".format(ref_path))
+                ref_parses = load_parses(ref_path)
 
             # Parse output into sentences and assotiate a list of linkages for each one of them.
             sentences = self._parse_batch_ps_output(text, options)

--- a/src/grammar_tester/parsevaluate.py
+++ b/src/grammar_tester/parsevaluate.py
@@ -318,7 +318,7 @@ def compare_ull_files(test_path, ref_path, options: int, **kwargs) -> ParseQuali
     total_parse_quality = ParseQuality()
     total_file_count = 0
 
-    stat_file = f"{kwargs.get('output_path', os.environ['PWD'])}/{os.path.split(test_path)[1]}.stat"
+    stat_file = f"{kwargs.get('output_path', os.environ['PWD'])}/{os.path.split(handle_path_string(test_path))[1]}.stat"
 
     parser_type = kwargs.get("parser_type", "link-grammar-exe")
 
@@ -408,11 +408,6 @@ def compare_ull_files(test_path, ref_path, options: int, **kwargs) -> ParseQuali
         except SentenceError as err:
             raise EvalError(str(err), file_name)
 
-        # except Exception as err:
-        #     logger.critical("evaluate(): Exception: " + str(err))
-        #     logger.debug(traceback.print_exc())
-        #     raise
-
     if not (os.path.isfile(test_path) or os.path.isdir(test_path)):
         raise FileNotFoundError("Path '" + test_path + "' does not exist.")
 
@@ -424,7 +419,7 @@ def compare_ull_files(test_path, ref_path, options: int, **kwargs) -> ParseQuali
     if output_path is None or not os.path.isdir(output_path):
         raise FileNotFoundError(f"Path '{output_path}' does not exist.")
 
-    # If corpus is a directory with multiple filese
+    # If corpus is a directory with multiple files
     if os.path.isdir(test_path):
         if not os.path.isdir(ref_path):
             raise ValueError("If 'corpus_path' is a directory 'reference_path' "

--- a/tests/test_lginprocparser.py
+++ b/tests/test_lginprocparser.py
@@ -4,7 +4,7 @@ import unittest
 from src.common.optconst import *
 from src.common.textprogress import TextProgress
 from src.grammar_tester.lginprocparser import LGInprocParser
-from src.grammar_tester import load_ull_file
+from src.grammar_tester import load_parses
 from src.grammar_tester.lgmisc import LGParseError, get_dir_name
 from src.common.tokencount import update_token_counts
 
@@ -229,14 +229,14 @@ class LGInprocParserTestCase(unittest.TestCase):
     def test_load_ull_file_not_found(self):
 
         with self.assertRaises(FileNotFoundError) as ctx:
-            data = load_ull_file("/var/tmp/something.txt")
+            data = load_parses("/var/tmp/something.txt")
 
         # self.assertEqual("list index out of range", str(ctx.exception))
 
     def test_load_ull_file_access_denied(self):
 
         with self.assertRaises(PermissionError) as ctx:
-            data = load_ull_file("/root/something.txt")
+            data = load_parses("/root/something.txt")
 
         # self.assertEqual("list index out of range", str(ctx.exception))
 

--- a/tests/test_parsevaluate.py
+++ b/tests/test_parsevaluate.py
@@ -29,14 +29,22 @@ class TestEvalMethods(unittest.TestCase):
     # @unittest.skip
     def test_get_parses(self):
         """ Test evaluation """
-        ref_data = load_ull_file("tests/test-data/parses/poc-turtle-mst/one-parse-expected.txt")
-        test_data = load_ull_file("tests/test-data/parses/poc-turtle-mst/one-parse-expected-mi.txt")
-        # print("ref_data='", ref_data, "'", file=sys.stderr)
-        # print("test_data='", test_data, "'", file=sys.stderr)
-        ref_parses = get_parses(ref_data)
-        test_parses = get_parses(test_data)
+        ref_parses = load_parses("tests/test-data/parses/poc-turtle-mst/one-parse-expected.txt")
+        test_parses = load_parses("tests/test-data/parses/poc-turtle-mst/one-parse-expected-mi.txt")
         eval_parses(test_parses, ref_parses, 0x00000000 | BIT_ULL_IN | BIT_NO_LWALL | BIT_NO_PERIOD)
         self.assertEqual(ref_parses, test_parses)
+
+    # # @unittest.skip
+    # def test_get_parses(self):
+    #     """ Test evaluation """
+    #     ref_data = load_ull_file("tests/test-data/parses/poc-turtle-mst/one-parse-expected.txt")
+    #     test_data = load_ull_file("tests/test-data/parses/poc-turtle-mst/one-parse-expected-mi.txt")
+    #     # print("ref_data='", ref_data, "'", file=sys.stderr)
+    #     # print("test_data='", test_data, "'", file=sys.stderr)
+    #     ref_parses = get_parses(ref_data)
+    #     test_parses = get_parses(test_data)
+    #     eval_parses(test_parses, ref_parses, 0x00000000 | BIT_ULL_IN | BIT_NO_LWALL | BIT_NO_PERIOD)
+    #     self.assertEqual(ref_parses, test_parses)
 
     @unittest.skip
     def test_get_parses_bug(self):
@@ -82,14 +90,22 @@ class TestEvalMethods(unittest.TestCase):
     # @unittest.skip
     def test_get_parses_start_from_digit(self):
         """ Test evaluation """
-        ref_data = load_ull_file("tests/test-data/parses/start-from-digit/start-from-digit.ull")
-        test_data = load_ull_file("tests/test-data/parses/start-from-digit/start-from-digit.ull")
-        # print("ref_data='", ref_data, "'", file=sys.stderr)
-        # print("test_data='", test_data, "'", file=sys.stderr)
-        ref_parses = get_parses(ref_data)
-        test_parses = get_parses(test_data)
+        ref_parses = load_parses("tests/test-data/parses/start-from-digit/start-from-digit.ull")
+        test_parses = load_parses("tests/test-data/parses/start-from-digit/start-from-digit.ull")
         # eval_parses(test_parses, ref_parses, False, sys.stderr)
         self.assertEqual(ref_parses, test_parses)
+
+    # # @unittest.skip
+    # def test_get_parses_start_from_digit(self):
+    #     """ Test evaluation """
+    #     ref_data = load_ull_file("tests/test-data/parses/start-from-digit/start-from-digit.ull")
+    #     test_data = load_ull_file("tests/test-data/parses/start-from-digit/start-from-digit.ull")
+    #     # print("ref_data='", ref_data, "'", file=sys.stderr)
+    #     # print("test_data='", test_data, "'", file=sys.stderr)
+    #     ref_parses = get_parses(ref_data)
+    #     test_parses = get_parses(test_data)
+    #     # eval_parses(test_parses, ref_parses, False, sys.stderr)
+    #     self.assertEqual(ref_parses, test_parses)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
New options implemented:
        -T              strict tokenization (treat tokenization discrepancies as fatal errors)
        -S              ignore sentences mismatch (continue evaluate even is sentences mismatch)
Some bugs fixed along the way.