### PR TITLE
GT fixes for proper handling input corpus CR/LFs

### DIFF
--- a/src/common/sedcommands.py
+++ b/src/common/sedcommands.py
@@ -12,13 +12,30 @@ def get_sed_regex(options: int) -> str:
     """
     # If BIT_ULL_IN sed filters links leaving only sentences and removes square brackets around tokens if any.
     if options & BIT_ULL_IN:
-        return r'/((^$)|(^([0-9]+[[:space:]]+.+){2}([[:space:]]+[-+0-9.e]+)?$))/d;s/\[([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27\xE2\x80\x94©®°•…≤±×΅⁻¹²³€αβπγδμεθ«»=+-]*)\]/\1/g;s/.*/\L\0/g' \
+        return r'/((^$)|(^\x0d$)|(^([0-9]+[[:space:]]+.+){2}([[:space:]]+[-+0-9.e]+)?$))/d;s/\[([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27\xE2\x80\x94©®°•…≤±×΅⁻¹²³€αβπγδμεθ«»=+-]*)\]/\1/g;s/.*/\L\0/g' \
             if options & BIT_INPUT_TO_LCASE \
-            else r'/((^$)|(^([0-9]+[[:space:]]+.+){2}([[:space:]]+[-+0-9.e]+)?$))/d;s/\[([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27\xE2\x80\x94©®°•…≤±×΅⁻¹²³€αβπγδμεθ«»=+-]*)\]/\1/g'
+            else r'/((^$)|(^\x0d$)|(^([0-9]+[[:space:]]+.+){2}([[:space:]]+[-+0-9.e]+)?$))/d;s/\[([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27\xE2\x80\x94©®°•…≤±×΅⁻¹²³€αβπγδμεθ«»=+-]*)\]/\1/g'
 
     # Otherwise sed removes only empty lines.
     else:
-        return r'/^$/d;s/.*/\L\0/g' if options & BIT_INPUT_TO_LCASE else r'/^$/d'
+        return r'/(^$)|(^\x0d$)/d;s/.*/\L\0/g' if options & BIT_INPUT_TO_LCASE else r'/(^$)|(^\x0d$)/d'
+
+# def get_sed_regex(options: int) -> str:
+#     """
+#     Return regular expression built according to the set of specified options.
+#
+#     :param options:     Grammar tester options.
+#     :return:            Regular expression string.
+#     """
+#     # If BIT_ULL_IN sed filters links leaving only sentences and removes square brackets around tokens if any.
+#     if options & BIT_ULL_IN:
+#         return r'/((^$)|(^([0-9]+[[:space:]]+.+){2}([[:space:]]+[-+0-9.e]+)?$))/d;s/\[([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27\xE2\x80\x94©®°•…≤±×΅⁻¹²³€αβπγδμεθ«»=+-]*)\]/\1/g;s/.*/\L\0/g' \
+#             if options & BIT_INPUT_TO_LCASE \
+#             else r'/((^$)|(^([0-9]+[[:space:]]+.+){2}([[:space:]]+[-+0-9.e]+)?$))/d;s/\[([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27\xE2\x80\x94©®°•…≤±×΅⁻¹²³€αβπγδμεθ«»=+-]*)\]/\1/g'
+#
+#     # Otherwise sed removes only empty lines.
+#     else:
+#         return r'/^$/d;s/.*/\L\0/g' if options & BIT_INPUT_TO_LCASE else r'/^$/d'
 
 
 def get_sed_cmd_common_part(options: int) -> list:
@@ -29,16 +46,3 @@ def get_sed_cmd_common_part(options: int) -> list:
     :return:            List of sed arguments.
     """
     return ["sed", "-Ee", get_sed_regex(options)]
-
-
-# def get_sed_regex(options: int) -> str:
-#
-#     # If BIT_ULL_IN sed filters links leaving only sentences and removes square brackets around tokens if any.
-#     if options & BIT_ULL_IN:
-#         return r'/\(^[0-9].*$\)\|\(^$\)/d;s/\[\([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27\xE2\x80\x94©®°•…≤±×΅⁻¹²³€αβπγδμεθ«»=+-]*\)\]/\1/g;s/.*/\L\0/g' \
-#             if options & BIT_INPUT_TO_LCASE \
-#             else r'/\(^[0-9].*$\)\|\(^$\)/d;s/\[\([a-z0-9A-Z.,:\@"?!*~()\/\#\$&;^%_`\0xe2\x27\xE2\x80\x94©®°•…≤±×΅⁻¹²³€αβπγδμεθ«»=+-]*\)\]/\1/g'
-#
-#     # Otherwise sed removes only empty lines.
-#     else:
-#         return r"/^$/d;s/.*/\L\0/g" if options & BIT_INPUT_TO_LCASE else r"/^$/d"

--- a/src/common/sentencecount.py
+++ b/src/common/sentencecount.py
@@ -27,10 +27,11 @@ def get_sentence_count(corpus_path: str, options: int) -> int:
     sentence_count = 0
 
     sed_cmd = get_sed_cmd_common_part(options) + [corpus_path]
+    sed_cmd[2] = sed_cmd[2] + ";/^\x0d$/d"
 
     try:
         # Get number of sentences in input file
-        with Popen(sed_cmd + ";/^\x0d$/d", stdout=PIPE) as proc_sed, \
+        with Popen(sed_cmd, stdout=PIPE) as proc_sed, \
              Popen(["wc", "-l"], stdin=proc_sed.stdout, stdout=PIPE, stderr=PIPE) as proc_wcl:
 
             # Closing grep output stream will terminate it's process.

--- a/src/common/sentencecount.py
+++ b/src/common/sentencecount.py
@@ -30,7 +30,7 @@ def get_sentence_count(corpus_path: str, options: int) -> int:
 
     try:
         # Get number of sentences in input file
-        with Popen(sed_cmd, stdout=PIPE) as proc_sed, \
+        with Popen(sed_cmd + ";/^\x0d$/d", stdout=PIPE) as proc_sed, \
              Popen(["wc", "-l"], stdin=proc_sed.stdout, stdout=PIPE, stderr=PIPE) as proc_wcl:
 
             # Closing grep output stream will terminate it's process.

--- a/src/common/sentencecount.py
+++ b/src/common/sentencecount.py
@@ -27,7 +27,7 @@ def get_sentence_count(corpus_path: str, options: int) -> int:
     sentence_count = 0
 
     sed_cmd = get_sed_cmd_common_part(options) + [corpus_path]
-    sed_cmd[2] = sed_cmd[2] + ";/^\x0d$/d"
+    # sed_cmd[2] = sed_cmd[2] + ";/^\x0d$/d"
 
     try:
         # Get number of sentences in input file

--- a/src/grammar_tester/lginprocparser.py
+++ b/src/grammar_tester/lginprocparser.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import re
 import logging
 from subprocess import PIPE, Popen
 
@@ -74,8 +75,10 @@ class LGInprocParser(AbstractFileParserClient):
 
         prev_sent = None
 
+        pattern = re.compile(r"\n\n[^\s]", re.M)
+
         # Parse output to get sentences and linkages in postscript notation
-        for block in text[pos:end].split("\n\n"):
+        for block in re.split(pattern, text[pos:end]):  # text[pos:end].split("\n\n"):
 
             block = block.strip()
 

--- a/src/grammar_tester/psparse.py
+++ b/src/grammar_tester/psparse.py
@@ -420,10 +420,8 @@ def get_sentence_text(text: str) -> Optional[str]:
     if match:
         return text[:match.start()].replace("\n", "")
 
-    # raise LGParseError(f"Unable to find echoed sentence in postscript parse:\n{text}")
-
-    logging.getLogger(__name__ + "get_sentence_text").debug(f"Unable to find echoed sentence in postscript "
-                                                            f"parse:\n{text}")
+    logging.getLogger(__name__ + ".get_sentence_text").debug(f"Unable to find echoed sentence in postscript "
+                                                             f"parse:\n{text}")
 
     return None
 
@@ -443,7 +441,5 @@ def get_linkage_cost(text: str):  # -> Optional[int, Tuple[int, str, int]]:
 
     if len(data) > 1:
         raise LGParseError(f"Found more than one linkage in: {text}")
-
-    # print(data if data is not None else "No matches found")
 
     return int(data[0][0]), (int(data[0][1]), Decimal(data[0][2]), int(data[0][3]))

--- a/src/grammar_tester/psparse.py
+++ b/src/grammar_tester/psparse.py
@@ -439,7 +439,7 @@ def get_linkage_cost(text: str):  # -> Optional[int, Tuple[int, str, int]]:
     if data is None or len(data) < 1:
         return None
 
-    if len(data) > 1:
-        raise LGParseError(f"Found more than one linkage in: {text}")
+    # if len(data) > 1:
+    #     raise LGParseError(f"Found more than one linkage in: {text}")
 
     return int(data[0][0]), (int(data[0][1]), Decimal(data[0][2]), int(data[0][3]))

--- a/tests/test_psparse.py
+++ b/tests/test_psparse.py
@@ -625,22 +625,6 @@ class TestPSParse(unittest.TestCase):
         # self.assertEqual('Jims lifted his miserable eyes .',
         #                  get_sentence_text(parses[1]))
 
-    def test_raw_split(self):
-
-        with open(r"tests/test-data/raw/GC_LGEnglish_noQuotes_manual.ull.raw.1lnkg", "r") as fd:
-            data: str = fd.read()
-
-        import re
-
-        pattern = re.compile(r"\n\n(?=[^\s])", re.M)
-
-        batches = re.split(pattern, data)
-
-        print(f"len={len(batches)}")
-
-        for i in range(3):
-            print(batches[i], file=sys.stderr)
-            print("-" * 30, file=sys.stderr)
 
 
     @staticmethod

--- a/tests/test_psparse.py
+++ b/tests/test_psparse.py
@@ -309,6 +309,50 @@ Found 2 linkages (2 had no P.P. violations)
 [0]
 """
 
+two_linkages_ps = \
+"""
+the old beast was whinnying on his shoulder .
+No complete linkages found.
+Found 3 linkages (3 had no P.P. violations) at null count 2
+        Linkage 1, cost vector = (UNUSED=2 DIS= 0.00 LEN=6)
+[(the)([old])(beast)(was)([whinnying])(on)(his)(shoulder)(.)]
+[[0 2 0 (SYER)][2 7 1 (EREF)][6 7 0 (ODEF)][5 6 0 (LLOD)][3 5 0 (LXLL)][7 8 0 (EFAT)]]
+[0]
+
+        Linkage 2, cost vector = (UNUSED=2 DIS= 0.00 LEN=6)
+[(the)([old])(beast)(was)([whinnying])(on)(his)(shoulder)(..y)]
+[[0 2 0 (SYER)][2 7 1 (EREF)][6 7 0 (ODEF)][5 6 0 (LLOD)][3 5 0 (LXLL)][7 8 0 (EFAT)]]
+[0]
+"""
+
+
+# two_linkages_ps = \
+# """
+# the old beast was whinnying on his shoulder .
+# No complete linkages found.
+# Found 3 linkages (3 had no P.P. violations) at null count 2
+#         Linkage 1, cost vector = (UNUSED=2 DIS= 0.00 LEN=6)
+# [(the)([old])(beast)(was)([whinnying])(on)(his)(shoulder)(.)]
+# [[0 2 0 (SYER)][2 7 1 (EREF)][6 7 0 (ODEF)][5 6 0 (LLOD)][3 5 0 (LXLL)][7 8 0 (EFAT)]]
+# [0]
+#
+#         Linkage 2, cost vector = (UNUSED=2 DIS= 0.00 LEN=6)
+# [(the)([old])(beast)(was)([whinnying])(on)(his)(shoulder)(..y)]
+# [[0 2 0 (SYER)][2 7 1 (EREF)][6 7 0 (ODEF)][5 6 0 (LLOD)][3 5 0 (LXLL)][7 8 0 (EFAT)]]
+# [0]
+#
+# Jims lifted his miserable eyes .
+# Found 2 linkages (2 had no P.P. violations)
+#         Linkage 1, cost vector = (UNUSED=0 DIS= 0.00 LEN=5)
+# [(jims)(lifted)(his)(miserable)(eyes)(.)]
+# [[0 1 0 (BFAS)][1 5 2 (ASAT)][1 4 1 (ASOR)][1 2 0 (ASOD)][3 4 0 (CCOR)]]
+# [0]
+#
+#         Linkage 2, cost vector = (UNUSED=0 DIS= 0.00 LEN=5)
+# [(jims)(lifted)(his)(miserable)(eyes)(..y)]
+# [[0 1 0 (BFAS)][1 5 2 (ASAT)][1 4 1 (ASOR)][1 2 0 (ASOD)][3 4 0 (CCOR)]]
+# [0]
+# """
 
 
 
@@ -571,6 +615,16 @@ class TestPSParse(unittest.TestCase):
 
         self.assertEqual('Mahbub Ali was hard upon boys who knew , or thought they knew , too much .',
                          get_sentence_text(parses[1]))
+
+        parses = split_ps_parses(two_linkages_ps)
+        self.assertEqual(1, len(parses))
+
+        self.assertEqual('the old beast was whinnying on his shoulder .',
+                         get_sentence_text(parses[0]))
+        #
+        # self.assertEqual('Jims lifted his miserable eyes .',
+        #                  get_sentence_text(parses[1]))
+
 
     @staticmethod
     def cmp_lists(list1: [], list2: []) -> bool:

--- a/tests/test_psparse.py
+++ b/tests/test_psparse.py
@@ -625,6 +625,23 @@ class TestPSParse(unittest.TestCase):
         # self.assertEqual('Jims lifted his miserable eyes .',
         #                  get_sentence_text(parses[1]))
 
+    def test_raw_split(self):
+
+        with open(r"tests/test-data/raw/GC_LGEnglish_noQuotes_manual.ull.raw.1lnkg", "r") as fd:
+            data: str = fd.read()
+
+        import re
+
+        pattern = re.compile(r"\n\n(?=[^\s])", re.M)
+
+        batches = re.split(pattern, data)
+
+        print(f"len={len(batches)}")
+
+        for i in range(3):
+            print(batches[i], file=sys.stderr)
+            print("-" * 30, file=sys.stderr)
+
 
     @staticmethod
     def cmp_lists(list1: [], list2: []) -> bool:


### PR DESCRIPTION
Regex and parser fixes for Windows style CR/LF found in input corpus (issue #231).