### PR TITLE
Avoid printing empty lines in pre-cleaner

### DIFF
--- a/src/pre_cleaner/pre_cleaner.py
+++ b/src/pre_cleaner/pre_cleaner.py
@@ -205,7 +205,8 @@ def Write_Output_Sentence(fo, sentence):
 	"""
 		writes sentence to the output file
 	"""
-	fo.write(sentence)
+	if not re.search(r"^\s*$", sentence):
+		fo.write(sentence)
 
 def Decode_Escaped(sentence):
 	"""
@@ -315,7 +316,6 @@ def Normalize_Sentence(sentence, separate_contractions):
 		Converts all different apostrophes, double quotes and dashes to 
 		standard symbols.
 		Also removes underscores (commonly used as underline markup).
-		Also converts asterisks to space
 		Also separates contractions if separete_contractions
 	"""
 

--- a/tests/test-data/pre-cleaner/split-books/pg9212.txt
+++ b/tests/test-data/pre-cleaner/split-books/pg9212.txt
@@ -5,6 +5,7 @@ Title: Snow Flakes (From "Twice Told Tales")
 Author: Nathaniel Hawthorne
 Posting Date: December 2, 2010 [EBook #9212] Release Date: November, 2005 First Posted: August 23, 2003 Last Updated: February 5, 2007
 Language: English
+* * * * * *
 *** START OF THIS PROJECT GUTENBERG EBOOK SNOW FLAKES ***
 Produced by David Widger.
 HTML version by Al Haines.


### PR DESCRIPTION
As per issue #238 , pre-cleaner was printing empty lines when all characters were removed from the line.
This fix avoids printing empty lines.

Test file was also updated