### PR TITLE
Added grammar-tester compatibility with sql-formatted dictionaries

### DIFF
--- a/src/common/dirhelper.py
+++ b/src/common/dirhelper.py
@@ -68,7 +68,7 @@ def traverse_directory(root: str, file_ext: str, file_arg_list: list=None, dir_a
                 if is_traversing:
                     traverse_directory(entry.path, file_ext, file_arg_list, dir_arg_list, True)
 
-            elif entry.is_file() and (len(file_ext) < 1 or (len(file_ext) and entry.path.endswith(file_ext))):
+            elif entry.is_file() and (len(file_ext) < 1 or (len(file_ext) and entry.path.find(file_ext) > -1)):
                 if file_arg_list is not None:
                     file_arg_list[0](entry.path, file_arg_list[1:])
 

--- a/src/common/dirhelper.py
+++ b/src/common/dirhelper.py
@@ -68,7 +68,6 @@ def traverse_directory(root: str, file_ext: str, file_arg_list: list=None, dir_a
                 if is_traversing:
                     traverse_directory(entry.path, file_ext, file_arg_list, dir_arg_list, True)
 
-            #elif entry.is_file() and (len(file_ext) < 1 or (len(file_ext) and entry.path.find(file_ext) > -1)):
             elif entry.is_file() and (len(file_ext) < 1 or (len(file_ext) and entry.path.endswith(file_ext))):
                 if file_arg_list is not None:
                     file_arg_list[0](entry.path, file_arg_list[1:])

--- a/src/common/dirhelper.py
+++ b/src/common/dirhelper.py
@@ -68,7 +68,8 @@ def traverse_directory(root: str, file_ext: str, file_arg_list: list=None, dir_a
                 if is_traversing:
                     traverse_directory(entry.path, file_ext, file_arg_list, dir_arg_list, True)
 
-            elif entry.is_file() and (len(file_ext) < 1 or (len(file_ext) and entry.path.find(file_ext) > -1)):
+            #elif entry.is_file() and (len(file_ext) < 1 or (len(file_ext) and entry.path.find(file_ext) > -1)):
+            elif entry.is_file() and (len(file_ext) < 1 or (len(file_ext) and entry.path.endswith(file_ext))):
                 if file_arg_list is not None:
                     file_arg_list[0](entry.path, file_arg_list[1:])
 

--- a/src/grammar_tester/grammartester.py
+++ b/src/grammar_tester/grammartester.py
@@ -304,7 +304,7 @@ class GrammarTester(AbstractGrammarTestClient):
         if self._is_dir_dict and not (self._options & BIT_EXISTING_DICT):
             dir_arg_list = [self._on_dict_dir]+parse_args if self._options & BIT_DPATH_CREATE else None
 
-            traverse_dir_tree(dict_path, ("dict", "dict.db"), [self._on_dict_file]+parse_args, dir_arg_list, True)
+            traverse_dir_tree(dict_path, ("4.0.dict", "dict.db"), [self._on_dict_file]+parse_args, dir_arg_list, True)
 
         # Otherwise it can be either single .dict file name or name of LG preinstalled dictionary e.g. 'en'
         else:

--- a/src/grammar_tester/grammartester.py
+++ b/src/grammar_tester/grammartester.py
@@ -304,7 +304,7 @@ class GrammarTester(AbstractGrammarTestClient):
         if self._is_dir_dict and not (self._options & BIT_EXISTING_DICT):
             dir_arg_list = [self._on_dict_dir]+parse_args if self._options & BIT_DPATH_CREATE else None
 
-            traverse_dir_tree(dict_path, ".4.0.dict", [self._on_dict_file]+parse_args, dir_arg_list, True)
+            traverse_dir_tree(dict_path, "dict", [self._on_dict_file]+parse_args, dir_arg_list, True)
 
         # Otherwise it can be either single .dict file name or name of LG preinstalled dictionary e.g. 'en'
         else:

--- a/src/grammar_tester/grammartester.py
+++ b/src/grammar_tester/grammartester.py
@@ -304,7 +304,7 @@ class GrammarTester(AbstractGrammarTestClient):
         if self._is_dir_dict and not (self._options & BIT_EXISTING_DICT):
             dir_arg_list = [self._on_dict_dir]+parse_args if self._options & BIT_DPATH_CREATE else None
 
-            traverse_dir_tree(dict_path, "dict", [self._on_dict_file]+parse_args, dir_arg_list, True)
+            traverse_dir_tree(dict_path, ("dict", "dict.db"), [self._on_dict_file]+parse_args, dir_arg_list, True)
 
         # Otherwise it can be either single .dict file name or name of LG preinstalled dictionary e.g. 'en'
         else:

--- a/src/grammar_tester/lginprocparser.py
+++ b/src/grammar_tester/lginprocparser.py
@@ -352,7 +352,7 @@ class LGInprocParser(AbstractFileParserClient):
 
             self._logger.debug(f"Dictionary version: {dict_ver}, link-parser version: {self._lg_version}")
 
-            if dict_ver != "0.0.0" and (self._lg_version < "5.5.0" and dict_ver >= "5.5.0" or
+            if dict_ver != "sql-dict" and dict_ver != "0.0.0" and (self._lg_version < "5.5.0" and dict_ver >= "5.5.0" or
                     self._lg_version >= "5.5.0" and dict_ver < "5.5.0"):
                 raise LGParseError(f"Wrong dictionary version: {dict_ver}, expected: {self._lg_version}")
 

--- a/src/grammar_tester/lgmisc.py
+++ b/src/grammar_tester/lgmisc.py
@@ -123,8 +123,11 @@ def create_grammar_dir(dict_file_path: str, grammar_path: str, template_path: st
         shutil.copytree(template_path, dict_path)
         logger.info("Directory '" + dict_path + "' with template files has been created.")
 
-        # Replace dictionary file '4.0.dict' with a new one
-        shutil.copy(dict_file_path, dict_path + "/4.0.dict")
+        # Replace dictionary file with a new one
+        if dict_file_path.endswith("db"):
+            shutil.copy(dict_file_path, dict_path + "/dict.db")
+        else:
+            shutil.copy(dict_file_path, dict_path + "/4.0.dict")
         logger.info("Dictionary file has been replaced with '" + dict_file_path + "'.")
 
     return dict_path

--- a/src/grammar_tester/lgmisc.py
+++ b/src/grammar_tester/lgmisc.py
@@ -45,18 +45,13 @@ def get_dir_name(file_name: str) -> (str, str):
     :return: tuple (template_grammar_directory_name, grammar_directory_name)
     """
     if file_name.endswith(".db"):
-        p = re.compile(
-        '(/?([+._:\w\d\[\]=~-]*/)*)((\S+))\.db')
+        regex_pattern = '(/?([+._:\w\d\[\]=~-]*/)*)((\S+))\.db'
     else:
-        p = re.compile(
-        '(/?([+._:\w\d\[\]=~-]*/)*)(([a-zA-Z-]+)_[0-9]{1,6}C_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9A-F]{4})\.(4\.0\.dict)')
+        regex_pattern = '(/?([+._:\w\d\[\]=~-]*/)*)(([a-zA-Z-]+)_[0-9]{1,6}C_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9A-F]{4})\.(4\.0\.dict)'
 
+    p = re.compile(regex_pattern)
     m = p.match(file_name)
-    if m is not None:
-        temp_dict_name = m.group(4)
-        dict_name = m.group(3)
-
-    return (None, None) (temp_dict_name, dict_name)
+    return (None, None) if m is None else (m.group(4), m.group(3))
 
 
 def create_grammar_dir(dict_file_path: str, grammar_path: str, template_path: str, options: int) -> str:

--- a/src/grammar_tester/lgmisc.py
+++ b/src/grammar_tester/lgmisc.py
@@ -27,7 +27,10 @@ def get_dir_name(file_name: str) -> (str, str):
     """
     Extract template grammar directory name and a name for new grammar directory
 
-    :param file_name: Grammar file name. It should have the following notation:
+    :param file_name: Grammar file name. 
+
+        If grammar is in sql format, the database file should end in ".db"
+        If grammar is in text format, it should have the following notation:
 
                 '<grammar-name>_<N>C_<yyyy-MM-dd>_<hhhh>.4.0.dict' (e.g. poc-turtle_8C_2018-03-03_0A10.4.0.dict)
 
@@ -41,11 +44,19 @@ def get_dir_name(file_name: str) -> (str, str):
 
     :return: tuple (template_grammar_directory_name, grammar_directory_name)
     """
-    p = re.compile(
+    if file_name.endswith(".db"):
+        p = re.compile(
+        '(/?([+._:\w\d\[\]=~-]*/)*)((\S+))\.db')
+    else:
+        p = re.compile(
         '(/?([+._:\w\d\[\]=~-]*/)*)(([a-zA-Z-]+)_[0-9]{1,6}C_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9A-F]{4})\.(4\.0\.dict)')
-    m = p.match(file_name)
 
-    return (None, None) if m is None else (m.group(4), m.group(3))
+    m = p.match(file_name)
+    if m is not None:
+        temp_dict_name = m.group(4)
+        dict_name = m.group(3)
+
+    return (None, None) (temp_dict_name, dict_name)
 
 
 def create_grammar_dir(dict_file_path: str, grammar_path: str, template_path: str, options: int) -> str:

--- a/src/grammar_tester/linkgrammarver.py
+++ b/src/grammar_tester/linkgrammarver.py
@@ -91,13 +91,13 @@ def get_lg_dict_version(dict_path: str) -> str:
     :return:
     """
 
-    if os.path.isdir(dict_path):
-        dict_path += "/4.0.dict"
-
-    # In case it's a binary file, returns generic db version
+    # In case dict is a binary file, returns special "version"
     f = os.popen('file -bi ' + dict_path, 'r')
     if not f.read().startswith('text'):
         return "sql-dict"
+
+    if os.path.isdir(dict_path):
+        dict_path += "/4.0.dict"
 
     with open(dict_path, "r") as file:
         text = file.read()

--- a/src/grammar_tester/linkgrammarver.py
+++ b/src/grammar_tester/linkgrammarver.py
@@ -91,13 +91,15 @@ def get_lg_dict_version(dict_path: str) -> str:
     :return:
     """
 
-    # In case dict is a binary file, returns special "version"
-    f = os.popen('file -bi ' + dict_path, 'r')
-    if not f.read().startswith('text'):
-        return "sql-dict"
+    dict_path2 = dict_path
 
     if os.path.isdir(dict_path):
+        dict_path2 += "/dict.db"
         dict_path += "/4.0.dict"
+
+    if os.path.isfile(dict_path2):
+        # In case dict is a binary file, returns special "version"
+        return "sql-dict"
 
     with open(dict_path, "r") as file:
         text = file.read()

--- a/src/grammar_tester/linkgrammarver.py
+++ b/src/grammar_tester/linkgrammarver.py
@@ -94,6 +94,11 @@ def get_lg_dict_version(dict_path: str) -> str:
     if os.path.isdir(dict_path):
         dict_path += "/4.0.dict"
 
+    # In case it's a binary file, returns generic db version
+    f = os.popen('file -bi ' + dict_path, 'r')
+    if not f.read().startswith('text'):
+        return "sql-dict"
+
     with open(dict_path, "r") as file:
         text = file.read()
 


### PR DESCRIPTION
Changes should allow compatibility with LG dictionaries in sql format, when link-grammar version is updated to 5.6.2. LG version of current ULL pipeline doesn't accept such dictionaries.
This code should not break existing functionalty, so I think there's no need to comment it out for later addition.